### PR TITLE
Add Brightness Adjustment Buttons to Color Picker Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## This Text is also available in
 
 [![English](https://img.shields.io/badge/EN-⚫-green.svg)]()
-
 [![Turkish](https://img.shields.io/badge/TR-◯-green.svg)](locals/tr.md) 
 
 ---

--- a/locals/tr.md
+++ b/locals/tr.md
@@ -10,7 +10,7 @@
 
 <!-- Plugin description -->
 
-#### The ultimate Android development companion that simplifies project setup and provides powerful development tools. Create new projects with modern dependencies, manage modules and features, and access essential utilities - all from a single, intuitive interface.
+#### Android geliştirme sürecinizin vazgeçilmez yardımcısı: Proje kurulumunu kolaylaştıran, güçlü geliştirme araçları sunan bu araç sayesinde modern bağımlılıklarla yeni projeler oluşturabilir, modülleri ve özellikleri yönetebilir, temel araçlara tek bir sezgisel arayüzden erişebilirsiniz.
 
 🚀 **Proje Şablonları** • 🏗️ **Modül & Feature Geliştirme** • 🎨 **Geliştirme Araçları** • ⚙️ **Takım Çalışması**
 
@@ -89,7 +89,7 @@ Ya da doğrudan [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/252
 
 <img title="" src="../images/new_project_cmp.png" alt="Compose Multiplatform" width="600">
 
-**Steps:**
+**Adımlar:**
 
 1. **File** → **New** → **Project**
 2. **Quick Project Wizard**’ı seç
@@ -320,7 +320,6 @@ Bu proje MIT Lisansı ile lisanslanmıştır – detaylar için [LICENSE](LICENS
 ## Diğer Dil Seçenekleri
 
 [![English](https://img.shields.io/badge/EN-◯-green.svg)](/)
-
 [![Turkish](https://img.shields.io/badge/TR-⚫-green.svg)]()
 
 ---

--- a/src/main/kotlin/com/github/cnrture/quickprojectwizard/common/ColorExtenions.kt
+++ b/src/main/kotlin/com/github/cnrture/quickprojectwizard/common/ColorExtenions.kt
@@ -1,0 +1,46 @@
+package com.github.cnrture.quickprojectwizard.common
+
+import androidx.compose.ui.graphics.Color
+
+
+fun Color.toHSV(): FloatArray {
+    val r = red
+    val g = green
+    val b = blue
+
+    val max = maxOf(r, g, b)
+    val min = minOf(r, g, b)
+    val delta = max - min
+
+    val h: Float
+    val s: Float
+    val v = max
+
+    s = if (max == 0f) 0f else delta / max
+
+    h = when {
+        delta == 0f -> 0f
+        max == r -> ((g - b) / delta + (if (g < b) 6f else 0f)) * 60f
+        max == g -> ((b - r) / delta + 2f) * 60f
+        else -> ((r - g) / delta + 4f) * 60f
+    }
+
+    return floatArrayOf(h % 360f, s, v)
+}
+
+fun Color.Companion.hsvToColor(h: Float, s: Float, v: Float): Color {
+    val c = v * s
+    val x = c * (1 - kotlin.math.abs((h / 60f) % 2 - 1))
+    val m = v - c
+
+    val (r1, g1, b1) = when {
+        h < 60f -> Triple(c, x, 0f)
+        h < 120f -> Triple(x, c, 0f)
+        h < 180f -> Triple(0f, c, x)
+        h < 240f -> Triple(0f, x, c)
+        h < 300f -> Triple(x, 0f, c)
+        else -> Triple(c, 0f, x)
+    }
+
+    return Color(r1 + m, g1 + m, b1 + m, 1f)
+}

--- a/src/main/kotlin/com/github/cnrture/quickprojectwizard/toolwindow/manager/colorpicker/ColorPickerContent.kt
+++ b/src/main/kotlin/com/github/cnrture/quickprojectwizard/toolwindow/manager/colorpicker/ColorPickerContent.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.cnrture.quickprojectwizard.common.hsvToColor
+import com.github.cnrture.quickprojectwizard.common.toHSV
 import com.github.cnrture.quickprojectwizard.service.AnalyticsService
 import com.github.cnrture.quickprojectwizard.components.QPWActionCard
 import com.github.cnrture.quickprojectwizard.components.QPWActionCardType
@@ -100,6 +102,11 @@ fun ColorPickerContent() {
                         colorInfo = colorInfo,
                         onCopyHex = { copyToClipboard(colorInfo.hex) },
                         onCopyRgb = { copyToClipboard(colorInfo.rgb) },
+                        onAdjustColorLightness = { percent ->
+                            val adjustedColor = adjustColorLightness(colorInfo.color, percent)
+                            val adjustedColorInfo = createColorInfo(adjustedColor)
+                            settings.addColorToHistory(adjustedColorInfo)
+                            colorHistory = settings.getColorHistory()}
                     )
                 }
             }
@@ -137,6 +144,7 @@ private fun ColorHistoryItem(
     colorInfo: ColorInfo,
     onCopyHex: () -> Unit,
     onCopyRgb: () -> Unit,
+    onAdjustColorLightness: (percent: Float) -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -166,6 +174,28 @@ private fun ColorHistoryItem(
                 Spacer(modifier = Modifier.height(8.dp))
                 ColorInfoRow(label = "RGB:", value = colorInfo.rgb)
             }
+
+            Column(
+                modifier = Modifier.width(IntrinsicSize.Max)
+            ) {
+                QPWActionCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    title = "+20%",
+                    icon = Icons.Rounded.ContentCopy,
+                    actionColor = QPWTheme.colors.purple,
+                    type = QPWActionCardType.SMALL,
+                    onClick = { onAdjustColorLightness(1.2f) })
+                Spacer(modifier = Modifier.height(8.dp))
+                QPWActionCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    title = "-20%",
+                    icon = Icons.Rounded.ContentCopy,
+                    actionColor = QPWTheme.colors.purple,
+                    type = QPWActionCardType.SMALL,
+                    onClick = { onAdjustColorLightness(0.8f) })
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
 
             Column {
                 QPWActionCard(
@@ -385,4 +415,11 @@ private fun copyToClipboard(text: String) {
     } catch (e: Exception) {
         println("❌ Error copying to clipboard: ${e.message}")
     }
+}
+
+private fun adjustColorLightness(color: Color, percent: Float): Color {
+    val hsv = color.toHSV()
+    hsv[2] = (hsv[2] * percent).coerceAtMost(1f)
+    val shiftedColor = Color.hsvToColor(hsv[0], hsv[1], hsv[2])
+    return shiftedColor
 }


### PR DESCRIPTION
This PR introduces functionality for the +20% and -20% buttons in the Color Picker module, allowing users to easily adjust the brightness of selected colors.

![image](https://github.com/user-attachments/assets/0d27d3f6-93ce-4469-9042-277f18dce708)
